### PR TITLE
Feature/message meta data (Requires FE changes!)

### DIFF
--- a/emoticons/chat/pipe.js
+++ b/emoticons/chat/pipe.js
@@ -10,9 +10,10 @@ function EmoticonPipe(packs, channel) {
  * @param  {Array}   message
  * @param  {Function} callback
  */
-EmoticonPipe.prototype.run = function (user, message, callback) {
+EmoticonPipe.prototype.run = function (user, messageObj, callback) {
     user.getResource('emoticonPack').then(function (pack) {
 
+        var message = messageObj.message;
         for (var i = 0, l = message.length; i < l; i++) {
             if (typeof message[i] === 'string') {
                 var emoticon = pack[message[i]];
@@ -28,7 +29,8 @@ EmoticonPipe.prototype.run = function (user, message, callback) {
             }
         }
 
-        callback(undefined, message);
+        messageObj.message = message;
+        callback(undefined, messageObj);
     });
 };
 

--- a/emoticons/chat/pipe.js
+++ b/emoticons/chat/pipe.js
@@ -7,7 +7,7 @@ function EmoticonPipe(packs, channel) {
 /**
  * Pipe function for emoticons, expects to come after words have been split.
  * Replaces emoticons (like ":)") in the message with proper components.
- * @param  {Array}   message
+ * @param  {Object}   messageObj
  * @param  {Function} callback
  */
 EmoticonPipe.prototype.run = function (user, messageObj, callback) {

--- a/emoticons/test/chat.test.js
+++ b/emoticons/test/chat.test.js
@@ -73,10 +73,11 @@ describe('emoticons', function () {
     it('parses simple', function (done) {
         emoticons.pipe(this.channel).run(this.user, [':)'], function (err, result) {
             expect(err).to.be.undefined;
+            console.log(result);
             expect(result).to.deep.equal([{ type: 'emoticon',
                 source: 'builtin',
                 pack: 'default',
-                coords: { x: 88, y: 0 },
+                coords: { x: 64, y: 0 },
                 text: ':)'
             }]);
             done();
@@ -90,7 +91,7 @@ describe('emoticons', function () {
                 type: 'emoticon',
                 source: 'builtin',
                 pack: 'default',
-                coords: { x: 88, y: 0 },
+                coords: { x: 64, y: 0 },
                 text: ':)'
             }, { foo: 'bar' }, 'asdf', {
                 type: 'emoticon',

--- a/emoticons/test/chat.test.js
+++ b/emoticons/test/chat.test.js
@@ -58,48 +58,56 @@ describe('emoticons', function () {
     });
 
     it('parses external', function (done) {
-        emoticons.pipe(this.channel).run(this.user, [':cat'], function (err, result) {
+        emoticons.pipe(this.channel).run(this.user, {meta: {}, message: [':cat']}, function (err, result) {
             expect(err).to.be.undefined;
-            expect(result).to.deep.equal([{ type: 'emoticon',
-                source: 'external',
-                pack: 'http://example.com/foo.png',
-                coords: { x: 0, y: 0 },
-                text: ':cat'
-            }]);
+            expect(result).to.deep.equal({
+                meta: {},
+                message: [{ type: 'emoticon',
+                    source: 'external',
+                    pack: 'http://example.com/foo.png',
+                    coords: { x: 0, y: 0 },
+                    text: ':cat'
+                }]
+            });
             done();
         });
     });
 
     it('parses simple', function (done) {
-        emoticons.pipe(this.channel).run(this.user, [':)'], function (err, result) {
+        emoticons.pipe(this.channel).run(this.user, {meta: {}, message: [':)']}, function (err, result) {
             expect(err).to.be.undefined;
-            console.log(result);
-            expect(result).to.deep.equal([{ type: 'emoticon',
-                source: 'builtin',
-                pack: 'default',
-                coords: { x: 64, y: 0 },
-                text: ':)'
-            }]);
+            expect(result).to.deep.equal({
+                meta: {},
+                message: [{ type: 'emoticon',
+                    source: 'builtin',
+                    pack: 'default',
+                    coords: { x: 64, y: 0 },
+                    text: ':)'
+                }]
+            });
             done();
         });
     });
 
     it('does not trip over objects', function (done) {
-        emoticons.pipe(this.channel).run(this.user, [':)', { foo: 'bar' }, 'asdf', ':astronaut'], function (err, result) {
+        emoticons.pipe(this.channel).run(this.user, {meta: {}, message: [':)', { foo: 'bar' }, 'asdf', ':astronaut']}, function (err, result) {
             expect(err).to.be.undefined;
-            expect(result).to.deep.equal([{
-                type: 'emoticon',
-                source: 'builtin',
-                pack: 'default',
-                coords: { x: 64, y: 0 },
-                text: ':)'
-            }, { foo: 'bar' }, 'asdf', {
-                type: 'emoticon',
-                source: 'builtin',
-                pack: 'space',
-                coords: { x: 0, y: 0 },
-                text: ':astronaut'
-            }]);
+            expect(result).to.deep.equal({
+                meta: {},
+                message: [{
+                    type: 'emoticon',
+                    source: 'builtin',
+                    pack: 'default',
+                    coords: { x: 64, y: 0 },
+                    text: ':)'
+                }, { foo: 'bar' }, 'asdf', {
+                    type: 'emoticon',
+                    source: 'builtin',
+                    pack: 'space',
+                    coords: { x: 0, y: 0 },
+                    text: ':astronaut'
+                }]
+            });
             done();
         });
     });

--- a/emoticons/test/chat.test.js
+++ b/emoticons/test/chat.test.js
@@ -81,7 +81,7 @@ describe('emoticons', function () {
                 message: [{ type: 'emoticon',
                     source: 'builtin',
                     pack: 'default',
-                    coords: { x: 64, y: 0 },
+                    coords: { x: 88, y: 0 },
                     text: ':)'
                 }]
             });
@@ -98,7 +98,7 @@ describe('emoticons', function () {
                     type: 'emoticon',
                     source: 'builtin',
                     pack: 'default',
-                    coords: { x: 64, y: 0 },
+                    coords: { x: 88, y: 0 },
                     text: ':)'
                 }, { foo: 'bar' }, 'asdf', {
                     type: 'emoticon',

--- a/giveaway/chat/start.js
+++ b/giveaway/chat/start.js
@@ -73,6 +73,6 @@ start.message = function (channel, body) {
         username: 'GiveawayBot',
         id: -1,
         roles: ['Admin']
-    }, body);
+    }, {meta: {}, message: body});
 };
 

--- a/giveaway/test/chat.test.js
+++ b/giveaway/test/chat.test.js
@@ -11,7 +11,7 @@ describe('giveaway starting', function () {
             username: 'GiveawayBot',
             id: -1,
             roles: ['Admin']
-        }, '@connor4312 won the giveaway!')).to.be.true;
+        }, {meta: {}, message: '@connor4312 won the giveaway!'})).to.be.true;
     });
 
     it('sends results at end of countdown', function () {

--- a/links/chat/links.js
+++ b/links/chat/links.js
@@ -53,7 +53,7 @@ Links.prototype.clickify = function (data, matches) {
  * Parses the message. Clickifies links if necessary, and throws an error
  * if links are not permitted.
  *
- * @param  {Array} data
+ * @param  {Object} data
  * @param  {Boolean} permitted
  * @param  {Boolean} clickable
  * @throws {NotAllowed}
@@ -62,8 +62,9 @@ Links.prototype.clickify = function (data, matches) {
 Links.prototype.parse = function (data, permitted) {
     // Loop through each "word" in the data. See if it matches and, if so,
     // either block or clickify.
-    for (var i = 0; i < data.length; i++) {
-        var part = data[i];
+    var message = data.message;
+    for (var i = 0; i < message.length; i++) {
+        var part = message[i];
 
         // Make sure the data is a string, and only parse if it passes
         // our pretest. Most messages aren't links, so this saves time.
@@ -77,19 +78,20 @@ Links.prototype.parse = function (data, permitted) {
                     throw new NotAllowed();
                 } else if (this.clickable) {
                     var parsed = this.clickify(part, match);
-                    data = data.slice(0, i).concat(parsed).concat(data.slice(i + 1));
+                    message = message.slice(0, i).concat(parsed).concat(message.slice(i + 1));
                     i += parsed.length;
                 }
             }
         }
     }
 
+    data.message = message;
     return data;
 };
 
 /**
  * Ensures the user can send a message before piping it on.
- * @param  {Array}   data
+ * @param  {Object}   data
  * @param  {Function} cb
  */
 Links.prototype.run = function (user, data, callback) {

--- a/links/test/chat.test.js
+++ b/links/test/chat.test.js
@@ -7,9 +7,9 @@ describe('links', function () {
 
     beforeEach(function () {
         data = {
-            nolink: ['Lorem ipsum dolor sit amet, consectetur adipisicing elit.'],
-            onelink: ['Lorem ipsum dolor sit amet, github.com adipisicing elit.'],
-            twolink: ['Lorem ipsum dolor sit amet, github.com adipisicing: https://beam.pro']
+            nolink: {meta: {}, message: ['Lorem ipsum dolor sit amet, consectetur adipisicing elit.']},
+            onelink: {meta: {}, message: ['Lorem ipsum dolor sit amet, github.com adipisicing elit.']},
+            twolink: {meta: {}, message: ['Lorem ipsum dolor sit amet, github.com adipisicing: https://beam.pro']}
         };
         links = Links.pipe(this.channel);
     });
@@ -70,7 +70,7 @@ describe('links', function () {
             var links = Links.pipe(this.channel);
             links.run(this.user, data.onelink, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal(['Lorem ipsum dolor sit amet, github.com adipisicing elit.']);
+                expect(out).to.deep.equal({meta: {}, message: ['Lorem ipsum dolor sit amet, github.com adipisicing elit.']});
                 done();
             });
         });
@@ -78,11 +78,14 @@ describe('links', function () {
             var links = Links.pipe(this.channel);
             links.run(this.user, data.onelink, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal([
-                    'Lorem ipsum dolor sit amet, ',
-                    { type: 'link', url: 'http://github.com', text: 'github.com' },
-                    ' adipisicing elit.'
-                ]);
+                expect(out).to.deep.equal({
+                    meta: {},
+                    message: [
+                        'Lorem ipsum dolor sit amet, ',
+                        { type: 'link', url: 'http://github.com', text: 'github.com' },
+                        ' adipisicing elit.'
+                    ]
+                });
                 done();
             });
         });
@@ -91,54 +94,63 @@ describe('links', function () {
     describe('parsing', function () {
         it('parses empty', function (done) {
             var links = Links.pipe(this.channel);
-            links.run(this.user, [], function (err, out) {
+            links.run(this.user, {meta: {}, message: []}, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal([]);
+                expect(out).to.deep.equal({meta: {}, message: []});
                 done();
             });
         });
         it('parses with objects', function (done) {
             var links = Links.pipe(this.channel);
-            links.run(this.user, ['hello', { foo: 2 }, 'world'], function (err, out) {
+            links.run(this.user, {meta: {}, message: ['hello', { foo: 2 }, 'world']}, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal(['hello', { foo: 2 }, 'world']);
+                expect(out).to.deep.equal({ meta: {}, message: ['hello', { foo: 2 }, 'world']});
                 done();
             });
         });
         it('parses mid text', function (done) {
             var links = Links.pipe(this.channel);
-            links.run(this.user, ['a github.com b'], function (err, out) {
+            links.run(this.user, {meta: {}, message: ['a github.com b']}, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal([
-                    'a ',
-                    { type: 'link', url: 'http://github.com', text: 'github.com' },
-                    ' b'
-                ]);
+                expect(out).to.deep.equal({
+                    meta: {},
+                    message: [
+                        'a ',
+                        { type: 'link', url: 'http://github.com', text: 'github.com' },
+                        ' b'
+                    ]
+                });
                 done();
             });
         });
         it('parses end of text, multiple', function (done) {
-            links.run(this.user, ['a github.com b google.com'], function (err, out) {
+            links.run(this.user, {meta: {}, message: ['a github.com b google.com']}, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal([
-                    'a ',
-                    { type: 'link', url: 'http://github.com', text: 'github.com' },
-                    ' b ',
-                    { type: 'link', url: 'http://google.com', text: 'google.com' },
-                ]);
+                expect(out).to.deep.equal({
+                    meta: {},
+                    message: [
+                        'a ',
+                        { type: 'link', url: 'http://github.com', text: 'github.com' },
+                        ' b ',
+                        { type: 'link', url: 'http://google.com', text: 'google.com' },
+                    ]
+                });
                 done();
             });
         });
         it('parses multiple segments', function (done) {
-            links.run(this.user, ['a github.com', { foo: 2 }, ' b google.com'], function (err, out) {
+            links.run(this.user, {meta: {}, message: ['a github.com', { foo: 2 }, ' b google.com']}, function (err, out) {
                 expect(err).to.be.undefined;
-                expect(out).to.deep.equal([
-                    'a ',
-                    { type: 'link', url: 'http://github.com', text: 'github.com' },
-                    { foo: 2 },
-                    ' b ',
-                    { type: 'link', url: 'http://google.com', text: 'google.com' },
-                ]);
+                expect(out).to.deep.equal({
+                    meta: {},
+                    message: [
+                        'a ',
+                        { type: 'link', url: 'http://github.com', text: 'github.com' },
+                        { foo: 2 },
+                        ' b ',
+                        { type: 'link', url: 'http://google.com', text: 'google.com' },
+                    ]
+                });
                 done();
             });
         });

--- a/me/chat/me.js
+++ b/me/chat/me.js
@@ -26,7 +26,7 @@ Me.prototype.run = function (user, data, callback) {
 
     if (msg.slice(0, len) === this.prefix) {
         data.meta.me = true;
-        data.message = [msg.slice(len)];
+        data.message[0] = msg.slice(len);
     }
     callback(undefined, data);
 };

--- a/me/chat/me.js
+++ b/me/chat/me.js
@@ -15,20 +15,20 @@ function Me () {
  * @param  {Function} cb
  */
 Me.prototype.run = function (user, data, callback) {
-    var msg = data[0];
+    var msg = data.message[0];
     var len = this.prefix.length;
 
     // If the message was tampered with, log a error but don't break...
-    if (data.length !== 1 || typeof msg !== 'string') {
+    if (data.message.length !== 1 || typeof msg !== 'string') {
         clip.error('Message was tampered with prior to the "me" widget getting it.');
         return callback(undefined, data);
     }
 
     if (msg.slice(0, len) === this.prefix) {
-        callback(undefined, [{ type: 'me', text: msg.slice(len) }]);
-    } else {
-        callback(undefined, data);
+        data.meta.me = true;
+        data.message = [msg.slice(len)];
     }
+    callback(undefined, data);
 };
 
 /**

--- a/me/chat/me.js
+++ b/me/chat/me.js
@@ -11,7 +11,7 @@ function Me () {
 /**
  * Turns the message into a single "me" component before passing it on.
  * @param  {User}    user
- * @param  {Array}   data
+ * @param  {Object}   data
  * @param  {Function} cb
  */
 Me.prototype.run = function (user, data, callback) {

--- a/me/test/chat.test.js
+++ b/me/test/chat.test.js
@@ -9,17 +9,23 @@ describe('me command', function () {
     });
 
     it('transforms prefixed messages', function (done) {
-        me.run(this.user, ['/me says hello!'], function (err, message) {
+        me.run(this.user, {meta: {}, message: ['/me says hello!']}, function (err, message) {
             expect(err).to.be.undefined;
-            expect(message).to.deep.equal([{ type: 'me', text: 'says hello!'}]);
+            expect(message).to.deep.equal({
+                meta: {me: true},
+                message: ['says hello!']
+            });
             done();
         });
     });
 
     it('passes on non prefixed', function (done) {
-        me.run(this.user, ['notme says hello!'], function (err, message) {
+        me.run(this.user, {meta: {}, message: ['notme says hello!']}, function (err, message) {
             expect(err).to.be.undefined;
-            expect(message).to.deep.equal(['notme says hello!']);
+            expect(message).to.deep.equal({
+                meta: {},
+                message: ['notme says hello!']
+            });
             done();
         });
     });

--- a/messaging/chat/chat.js
+++ b/messaging/chat/chat.js
@@ -50,7 +50,7 @@ chat.sendMessage = function (channel, user, message, callback) {
 /**
  * Sends a chat message out to the channel.
  * @param  {Objec} user
- * @param  {Array} msg
+ * @param  {Object} msg
  */
 chat.sendMessageRaw = function (channel, user, msg) {
     var message = {

--- a/messaging/chat/chat.js
+++ b/messaging/chat/chat.js
@@ -15,7 +15,7 @@ function noop () {}
  * @param  {Function} callback
  */
 chat.parseMessage = function (channel, user, message, callback) {
-    var stream = new MessageStream([message], channel.messagePipes);
+    var stream = new MessageStream({message: [message], meta: {}}, channel.messagePipes);
 
     stream.on('aborted', function (err) {
         callback(err);

--- a/messaging/chat/transforms.js
+++ b/messaging/chat/transforms.js
@@ -5,15 +5,16 @@ transforms.splitWords = function () {
      * Takes a message string and splits it into an array of words and spaces,
      * sending chunks down the pipe as we parse.
      * @param  {User} user
-     * @param  {Array} strs
-     * @return {Array}
+     * @param  {Object} data
+     * @return {Object}
      */
-    return { run: function (user, strs, cb) {
+    return { run: function (user, data, cb) {
         var output = [];
+        var message = data.message;
 
         // Iterate through every chunk in the string...
-        for (var j = 0; j < strs.length; j++) {
-            var str = strs[j];
+        for (var j = 0; j < message.length; j++) {
+            var str = message[j];
 
             // If it's not a string (already been parsed into something,
             // just add it on the output).
@@ -36,7 +37,9 @@ transforms.splitWords = function () {
             output.push(str.slice(k, i));
         }
 
-        cb(null, output);
+        data.message = output;
+
+        cb(null, data);
     }};
 };
 
@@ -44,12 +47,13 @@ transforms.finalize = function () {
     /**
      * Transforms the strings in the list to
      * @param  {User} user
-     * @param  {Array} data
-     * @return {Array}
+     * @param  {Object} data
+     * @return {Object}
      */
     return { run: function (user, data, cb) {
         var spool = [];
         var output = [];
+        var message = data.message;
 
         /**
          * Takes spooled strings and adds a text component to
@@ -63,17 +67,18 @@ transforms.finalize = function () {
         }
 
         // The spool on the strings to the spool or output.
-        for (var i = 0; i < data.length; i++) {
-            if (typeof data[i] === 'string') {
-                spool.push(data[i]);
+        for (var i = 0; i < message.length; i++) {
+            if (typeof message[i] === 'string') {
+                spool.push(message[i]);
             } else {
                 cutSpool();
-                output.push(data[i]);
+                output.push(message[i]);
             }
         }
 
         cutSpool();
-        cb(null, output);
+        data.message = output;
+        cb(null, data);
     }};
 };
 
@@ -81,7 +86,7 @@ transforms.identity = function () {
     /**
      * Identity transform. Does not modify data.
      * @param  {User}   user
-     * @param  {Array}   data
+     * @param  {Object}   data
      * @param  {Function} cb
      */
     return { run: function (user, data, cb) {

--- a/slowchat/chat/slowchat.js
+++ b/slowchat/chat/slowchat.js
@@ -83,7 +83,7 @@ SlowChat.prototype.canSend = function (user) {
 
 /**
  * Ensures the user can send a message before piping it on.
- * @param  {Array}   data
+ * @param  {Object}   data
  * @param  {Function} cb
  */
 SlowChat.prototype.run = function (user, data, cb) {


### PR DESCRIPTION
NOTE: Don't merge this until the frontend changes are ready too!

As mentioned in issue #16, the /me widget would get a message first, and put the entire message into an object with type 'me'. This meant that the widgets that come later, like the emoticons widget, would ignore it as it had already been parsed.

This changes our message format from a simple array to an object that has a `meta` attribute. The /me widget can then add data to the `meta` attribute so the front end knows to style it, and removes the '/me' from the start of the message, but leaves the rest of the message as an array for other widgets to manipulate.

For example, previously we would get a message like so:
`['/me is testing']`
And it would be transformed into:
`[{type: 'me', text: 'is testing'}]`

But after this change we get a message like so:
`{meta: {}, message: ['/me is testing']}`
And it would be transformed into:
`{meta: {me: true}, message: ['is testing']}`

So all widgets and transforms now perform their operations on the `message` attribute, and are free to add data to the `meta` attribute, which will be available to later widgets and the frontend.