### PR TITLE
Make sure an emoticon has a source, pack and coords

### DIFF
--- a/emoticons/chat/pipe.js
+++ b/emoticons/chat/pipe.js
@@ -16,11 +16,9 @@ EmoticonPipe.prototype.run = function (user, messageObj, callback) {
         var message = messageObj.message;
         for (var i = 0, l = message.length; i < l; i++) {
             if (typeof message[i] === 'string') {
-                var emoticon = pack[message[i]];
-                if (emoticon &&
-                    emoticon.source &&
-                    emoticon.pack &&
-                    emoticon.coords) {
+                var isEmoticon = pack.hasOwnProperty(message[i]);
+                if (isEmoticon) {
+                    var emoticon = pack[message[i]];
                     message[i] = {
                         type: 'emoticon',
                         source: emoticon.source,

--- a/emoticons/chat/pipe.js
+++ b/emoticons/chat/pipe.js
@@ -17,7 +17,10 @@ EmoticonPipe.prototype.run = function (user, messageObj, callback) {
         for (var i = 0, l = message.length; i < l; i++) {
             if (typeof message[i] === 'string') {
                 var emoticon = pack[message[i]];
-                if (emoticon) {
+                if (emoticon &&
+                    emoticon.source &&
+                    emoticon.pack &&
+                    emoticon.coords) {
                     message[i] = {
                         type: 'emoticon',
                         source: emoticon.source,

--- a/emoticons/test/chat.test.js
+++ b/emoticons/test/chat.test.js
@@ -111,4 +111,15 @@ describe('emoticons', function () {
             done();
         });
     });
+
+    it('does not try to turn the word "constructor" into an emoticon', function (done) {
+        emoticons.pipe(this.channel).run(this.user, {meta: {}, message: ['hello constructor test']}, function (err, result) {
+            expect(err).to.be.undefined;
+            expect(result).to.deep.equal({
+                meta: {},
+                message: ['hello constructor test']
+            });
+            done();
+        });
+    });
 });

--- a/messaging/chat/chat.js
+++ b/messaging/chat/chat.js
@@ -59,8 +59,7 @@ chat.sendMessageRaw = function (channel, user, msg) {
         user_name: user.username,
         user_id: user.id,
         user_roles: user.roles,
-        message: msg.message,
-        meta: msg.meta
+        message: msg
     };
 
     channel.publish('ChatMessage', message);


### PR DESCRIPTION
Chat was trying to render "constructor" as an emoticon, as it exists as a function in the Object prototype. Now, we check that we have source, pack and coords before trying to parse something as an emoticon.