### PR TITLE
When the user is changed (i.e. on subscribe), clear their resource cache

### DIFF
--- a/resources/chat/resources.js
+++ b/resources/chat/resources.js
@@ -28,6 +28,7 @@ resources.load = function (type, alias, handler) {
  */
 resources.bindUser = function (user) {
     user.getResource = resources.get;
+    user.on('change', () => { delete user._resourceCache });
 };
 
 /**

--- a/resources/test/chat.test.js
+++ b/resources/test/chat.test.js
@@ -16,6 +16,12 @@ describe('resource', function () {
         expect(resources.inQuery()).to.equal('\'a\', \'b\'');
     });
 
+    it('clears the resource cache on change', function () {
+        this.user._resourceCache = {};
+        this.user.emit('change');
+        expect(this.user._resourceCache).to.be.undefined;
+    });
+
     describe('load', function () {
         it('returns from the user cache when present', function (done) {
             this.user._resourceCache = { a: ['bar'] };

--- a/test/fixture/channel.js
+++ b/test/fixture/channel.js
@@ -1,5 +1,5 @@
-var sinon = require('sinon');
 var EventEmitter = require('events').EventEmitter;
+var sinon = require('sinon');
 
 module.exports = function () {
     var channel = new EventEmitter();

--- a/test/fixture/user.js
+++ b/test/fixture/user.js
@@ -1,12 +1,14 @@
+var EventEmitter = require('events').EventEmitter;
 var sinon = require('sinon');
 
 module.exports = function (channel) {
-    return {
-        getChannel: sinon.stub().returns(channel),
-        getId: sinon.stub().returns(42),
-        getUsername: sinon.stub().returns('connor4312'),
-        getRoles: sinon.stub().returns(['Developer', 'User']),
-        permissions: [],
-        hasPermission: function (p) { return this.permissions.indexOf(p) !== -1; }
-    };
+    var user = new EventEmitter();
+    user.getChannel = sinon.stub().returns(channel);
+    user.getId = sinon.stub().returns(42);
+    user.getUsername = sinon.stub().returns('connor4312');
+    user.getRoles = sinon.stub().returns(['Developer', 'User']);
+    user.permissions = [];
+    user.hasPermission = function (p) { return this.permissions.indexOf(p) !== -1; };
+
+    return user;
 };


### PR DESCRIPTION
This makes it so when a user subs, it automatically can start using the new emotes.

Fixes https://trello.com/c/HpkNJPz3/93-after-subscribing-emotes-are-not-available-until-the-user-refreshes